### PR TITLE
adding FLUIDOS node quick-start sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # Quick Start
 
 ## Documentation
+
 The most up-to-date documentation about the project, the overall architecture, and the current implementation of the components is available in the [Docs](https://github.com/fluidos-project/Docs) repository.
 
 ## Software components
+
+- FLUIDOS node: a component that can consist of either a single device or a set of devices, primarily serving as a representation of a Kubernetes node. It is managed by a singular Kubernetes Control Plane. For additional information, kindly consult the [FLUIDOS node repository](https://github.com/fluidos-project/node)
+
+- FLUIDOS at the edge TODO
+
+## Click-and-play playground
+
+### FLUIDOS node
+
+Explore the FLUIDOS node with our step-by-step guide to effortlessly set up a FLUIDOS Node testbed using KIND (Kubernetes in Docker). This is the simplest method for installing the FLUIDOS node on your local machine. [Begin your journey here.](https://github.com/fluidos-project/node/tree/main/testbed/kind)
+
+### Fluidos at edge
+
+TODO
+
+## Roadmap
+
+TODO


### PR DESCRIPTION
Hi everybody.
This PR focuses on providing a concise overview of the FLUIDOS node within the quickstart repository, specifically tailored to meet the requirements outlined in WP9.

In this PR, I've offered a brief introduction to the FLUIDOS node technology, with the intention of keeping the details streamlined in this message. The comprehensive information can be found in the main repository, ensuring that anyone interested can dive deeper into the intricacies of the technology.

Moreover, I've adopted a similar approach for the node's quick setup, providing a short introduction here and guiding users to refer to the main repository documentation for a more in-depth understanding.

I'm eager to receive any feedback or suggestions you may have

Looking forward to your input.

Francesco
